### PR TITLE
Use dependency instead of find_library and avoid relying on rizin exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Requires [rizin](https://github.com/rizinorg/rizin).
 Follow the following steps to install jsdec
  - clone this repository
  - Run `cd p`
- - Run `meson -Djsc_folder=".." build` to create the build folder
+ - Run `meson -Djsc_folder=".." --prefix=/usr build` to create the build folder
  - Run `ninja -C build install` to build the shared library and to install it 
 
 
-# Install in home folder
+# Install in home folder (or in other paths)
 
-If you want to install in the HOME folder, you can call `rizin -H RZ_USER_PLUGINS` for the exact user plugin path
-
+If you want to install in the HOME folder or in other non standard paths, just
+set the `prefix` to a different value
  - Run `cd p`
- - Run ``meson -Djsc_folder=".." -Drizin_plugdir=`rizin -H RZ_USER_PLUGINS` build``
+ - Run ``meson -Djsc_folder=".." --prefix=~/.local build``
  - Run `ninja -C build install`
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -11,13 +11,22 @@ Converts asm to pseudo-C code.
 
 Requires [rizin](https://github.com/rizinorg/rizin).
 
-# Install
+# Install system wide
 
 Follow the following steps to install jsdec
  - clone this repository
  - Run `cd p`
  - Run `meson -Djsc_folder=".." build` to create the build folder
  - Run `ninja -C build install` to build the shared library and to install it 
+
+
+# Install in home folder
+
+If you want to install in the HOME folder, you can call `rizin -H RZ_USER_PLUGINS` for the exact user plugin path
+
+ - Run `cd p`
+ - Run ``meson -Djsc_folder=".." -Drizin_plugdir=`rizin -H RZ_USER_PLUGINS` build``
+ - Run `ninja -C build install`
 
 # Usage
 

--- a/p/meson.build
+++ b/p/meson.build
@@ -1,46 +1,25 @@
 project('jsdec', 'c', meson_version: '>=0.46.0')
 
 pyth = import('python').find_installation()
-rizin = find_program('rizin', required: false)
 cc = meson.get_compiler('c')
 
-incs = ['.']
+incs = ['.', 'duktape']
 deps = []
 c_args = []
 
-rizin_incdir = get_option('rizin_incdir')
-if rizin_incdir == '' and rizin.found()
-  rizin_incdir = run_command(rizin, '-H', 'RZ_INCDIR').stdout().strip()
-endif
-
-rizin_libdir = get_option('rizin_libdir')
-if rizin_libdir == '' and rizin.found()
-  rizin_libdir = run_command(rizin, '-H', 'RZ_LIBDIR').stdout().strip()
-endif
-
 rizin_plugdir = get_option('rizin_plugdir')
-if rizin_plugdir == '' and rizin.found()
-  rizin_plugdir = run_command(rizin, '-H', 'RZ_USER_PLUGINS').stdout().strip()
-  if rizin_plugdir == ''
-    rizin_plugdir = get_option('libdir')
-  endif
+if rizin_plugdir == ''
+  rizin_plugdir = join_paths(get_option('libdir'), 'rizin', 'plugins')
 endif
 
-plugin_jsdec_dir = join_paths(rizin_plugdir, 'jsdec')
+plugin_jsdec_dir = join_paths(get_option('prefix'), rizin_plugdir, 'jsdec')
 
-libs = ['rz_core', 'rz_util', 'rz_cons', 'rz_config', 'rz_io']
-foreach lib : libs
-  deps += cc.find_library(lib, dirs: rizin_libdir)
-endforeach
-
+deps += dependency('rz_core')
+deps += dependency('rz_util')
+deps += dependency('rz_cons')
+deps += dependency('rz_config')
+deps += dependency('rz_io')
 deps += cc.find_library('m', required: false)
-
-if rizin_incdir != ''
-  incs += rizin_incdir
-  incs += rizin_incdir + '/sdb'
-endif
-
-incs += 'duktape'
 
 files = [
   'core_pdd.c',
@@ -67,8 +46,6 @@ if jsc_folder != ''
   )
 endif
 
-message('Rizin Include Dir: ' + rizin_incdir)
-message('Rizin Library Dir: ' + rizin_libdir)
 message('Rizin Plugin Dir:  ' + rizin_plugdir)
 if jsc_folder != ''
   message('JS to C Folder:    ' + jsc_folder)

--- a/p/meson.build
+++ b/p/meson.build
@@ -1,4 +1,4 @@
-project('jsdec', 'c', meson_version: '>=0.46.0')
+project('jsdec', 'c', meson_version: '>=0.51.0')
 
 pyth = import('python').find_installation()
 cc = meson.get_compiler('c')
@@ -7,19 +7,22 @@ incs = ['.', 'duktape']
 deps = []
 c_args = []
 
-rizin_plugdir = get_option('rizin_plugdir')
-if rizin_plugdir == ''
-  rizin_plugdir = join_paths(get_option('libdir'), 'rizin', 'plugins')
-endif
-
-plugin_jsdec_dir = join_paths(get_option('prefix'), rizin_plugdir, 'jsdec')
-
-deps += dependency('rz_core')
+rz_core_dep = dependency('rz_core')
+deps += rz_core_dep
 deps += dependency('rz_util')
 deps += dependency('rz_cons')
 deps += dependency('rz_config')
 deps += dependency('rz_io')
 deps += cc.find_library('m', required: false)
+
+rizin_plugdir = get_option('rizin_plugdir')
+if rizin_plugdir == ''
+  rizin_plugdir = rz_core_dep.get_variable(pkgconfig: 'plugindir', cmake: 'rz_core_PLUGINDIR')
+  plugin_jsdec_dir = join_paths(get_option('prefix'), rizin_plugdir, 'jsdec')
+else
+  plugin_jsdec_dir = join_paths(rizin_plugdir, 'jsdec')
+endif
+
 
 files = [
   'core_pdd.c',
@@ -46,7 +49,7 @@ if jsc_folder != ''
   )
 endif
 
-message('Rizin Plugin Dir:  ' + rizin_plugdir)
+message('Rizin Plugin Dir:  ' + plugin_jsdec_dir)
 if jsc_folder != ''
   message('JS to C Folder:    ' + jsc_folder)
 endif

--- a/p/meson_options.txt
+++ b/p/meson_options.txt
@@ -1,4 +1,2 @@
-option('rizin_libdir', type: 'string', value: '', description: 'rizin library directory')
-option('rizin_incdir', type: 'string', value: '', description: 'rizin include directory')
 option('rizin_plugdir', type: 'string', value: '', description: 'rizin install directory')
 option('jsc_folder', type: 'string', value: '', description: 'When a path is defined, the js code, found in its subfolders, is embedded into the C code.')


### PR DESCRIPTION
pkg-config files already contain all the required include and library
dependencies (plus optional CFLAGS) necessary to compile against Rizin
libraries. One can specify --pkg-config-path to specify the pkg-config
path to use if not in the standard directory. Also, by setting the
plugdir to prefix/lib/rizin/plugins (instead of RZ_USER_PLUGINS from the
rizin executable) the person compiling the plugin can choose whether to
install the plugin in a system-wide location (e.g. a maintainer of a
linux distro who wants to ship jsdec as a package would want to install
it in /usr/lib64/rizin/plugins and not in ~/.local/lib64/rizin/plugins)
or in the home location.