### PR TITLE
Backport 285

### DIFF
--- a/.github/workflows/continuous-tests.yml
+++ b/.github/workflows/continuous-tests.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '16'
       - name: eslint
         run: chmod +x .ci-scripts/ci-eslint.sh && .ci-scripts/ci-eslint.sh ${GITHUB_REF##*/}
 

--- a/libdec/arch/riscv.js
+++ b/libdec/arch/riscv.js
@@ -20,6 +20,7 @@
             //pointer, register, bits, is_signed
             return Base.read_memory(arg[1], e.opd[0], bits, !unsigned);
         }
+        arg[0] = arg[0].length > 0 ? parseInt(arg[0]) : NaN;
         if (!isNaN(arg[0])) {
             if (arg[0] < 0) {
                 arg[0] = " - 0x" + Math.abs(arg[0]).toString(16);
@@ -124,7 +125,7 @@
         ];
         var address = [
             function(e, addr) {
-                var imm32 = parseInt(instr.parsed.opd[1]).toString(16) << 12;
+                var imm32 = instr.parsed.opd[1] << 12;
                 return Long.fromNumber(imm32, true);
             },
             function(e, addr) {
@@ -173,7 +174,7 @@
             },
             lui: function(instr) {
                 var dst = instr.parsed.opd[0];
-                var imm20 = parseInt(instr.parsed.opd[1]).toString(16) << 12;
+                var imm20 = instr.parsed.opd[1] << 12;
                 return Base.assign(dst, '0x' + imm20.toString(16)) ;
             },
             lb: function(instr) {


### PR DESCRIPTION
lui decompilation is wrong:
* original produces "a0 = 0x429a000; return;" for "lui a0, 0x17050; ret", but shall produce "a0 = 0x17050000; return;"
* Note that lui followed by addi is correct and is unaffected.

l{d,w,h,b}[u] decompilation is wrong:
* original produces "ra = *((sp + 0x40));" for "ld ra, 40(sp)"
(note that '40' decimal is simply left unaffected and gets substituted to '0x40' in result,
giving impression that this is now correct hex value), but shall produce "ra = *((sp + 0x28));".
This affects all load insns of all types.
* Note that store insns are unaffected by this bug.