### PR TITLE
Fix core conf on cutter plugin

### DIFF
--- a/c/jsdec-cutter.c
+++ b/c/jsdec-cutter.c
@@ -319,6 +319,21 @@ static RzAnnotatedCode *parse_json(RzStrBuf *sb) {
 	return code;
 }
 
+RZ_API void jsdec_init_config(RzCore *core) {
+	RzConfig *cfg = core->config;
+
+	rz_config_lock(cfg, false);
+	SETPREF("jsdec.asm", "false", "if true, shows pseudo next to the assembly.");
+	SETPREF("jsdec.blocks", "false", "if true, shows only scopes blocks.");
+	SETPREF("jsdec.casts", "false", "if false, hides all casts in the pseudo code.");
+	SETPREF("jsdec.debug", "false", "do not catch exceptions in jsdec.");
+	SETPREF("jsdec.highlight", "default", "highlights the current address.");
+	SETPREF("jsdec.paddr", "false", "if true, all xrefs uses physical addresses compare.");
+	SETPREF("jsdec.slow", "false", "load all the data before to avoid multirequests to rizin.");
+	SETPREF("jsdec.xrefs", "false", "if true, shows all xrefs in the pseudo code.");
+	rz_config_lock(cfg, true);
+}
+
 RZ_API RzAnnotatedCode *jsdec_as_annotation(RzCore *core, ut64 addr) {
 	ExecContext ectx;
 	ectx.core = core;

--- a/cutter-plugin/JSDecDecompiler.cpp
+++ b/cutter-plugin/JSDecDecompiler.cpp
@@ -10,9 +10,11 @@
 
 #include "jsdec-cutter.h"
 
-JSDecDecompiler::JSDecDecompiler(QObject *parent)
-    : Decompiler("jsdec", "jsdec", parent) {
+JSDecDecompiler::JSDecDecompiler(CutterCore *core)
+    : Decompiler("jsdec", "jsdec", core) {
 	task = nullptr;
+	RzCoreLocked c = core->core();
+	jsdec_init_config(c);
 }
 
 void JSDecDecompiler::decompileAt(RVA addr) {

--- a/cutter-plugin/JSDecDecompiler.h
+++ b/cutter-plugin/JSDecDecompiler.h
@@ -13,7 +13,7 @@ class JSDecDecompiler: public Decompiler
 		RizinFunctionTask *task;
 
 	public:
-		JSDecDecompiler(QObject *parent = nullptr);
+		JSDecDecompiler(CutterCore *core = nullptr);
 		virtual void decompileAt(RVA addr) override;
 		virtual bool isRunning() override { return task != nullptr; }
 };

--- a/include/jsdec-cutter.h
+++ b/include/jsdec-cutter.h
@@ -10,6 +10,7 @@ extern "C" {
 
 #include <rz_util/rz_annotated_code.h>
 
+RZ_API void jsdec_init_config(RzCore *core);
 RZ_API RzAnnotatedCode *jsdec_as_annotation(RzCore *core, ut64 addr);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes
```
[x] Use -AA or aaaa to perform additional experimental analysis.
ERROR: core: Invalid config key 'jsdec.casts'
ERROR: core: Invalid config key 'jsdec.asm'
ERROR: core: Invalid config key 'jsdec.blocks'
ERROR: core: Invalid config key 'jsdec.xrefs'
ERROR: core: Invalid config key 'jsdec.paddr'
ERROR: core: Invalid config key 'jsdec.debug'
ERROR: core: Invalid config key 'jsdec.highlight'
ERROR: core: Invalid config key 'jsdec.slow'
ERROR: core: Invalid config key 'jsdec.slow'
```