### PR TITLE
Use C++20 for jsdec Cutter plugin

### DIFF
--- a/cutter-plugin/CMakeLists.txt
+++ b/cutter-plugin/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(cutter-jsdec-plugin)
 
+set(CMAKE_CXX_STANDARD 20)
+
 set(CUTTER_INSTALL_PLUGDIR "share/rizin/cutter/plugins/native" CACHE STRING "Directory to install Cutter plugin into")
 set(JSDEC_BUILD_DIR "../build" CACHE STRING "Directory where to find libjsdec.a")
 


### PR DESCRIPTION
This pr uses C++20 for the jsdec Cutter plugin since apparently that is what is needed by MSVC nowadays:

<img width="1129" height="73" alt="jsdec-c++20" src="https://github.com/user-attachments/assets/acd9fb47-0642-4bea-af4e-e96dfb91b5dd" />

(https://github.com/rizinorg/cutter/actions/runs/22019977842/job/63627441483#step:9:11698)