### PR TITLE
Rename `master` branch to `stable`

### DIFF
--- a/.ci-scripts/ci-build-linux.sh
+++ b/.ci-scripts/ci-build-linux.sh
@@ -6,7 +6,7 @@ CI_JSDEC="$PWD"
 CI_RZ_VERSION=$2
 
 if [ "$CI_BRANCH" != "dev" ]; then
-	# master branch always build against latest release of rizin
+	# stable branch always build against latest release of rizin
 	CI_RZ_VERSION=$(curl -s GET https://api.github.com/repos/rizinorg/rizin/tags\?per_page\=1 | jq -r '.[].name')
 else
 	CI_RZ_VERSION="$CI_BRANCH"
@@ -25,7 +25,7 @@ if [ "$CI_BRANCH" == "dev" ]; then
 	wget -O "rizin.tar.gz" "https://github.com/rizinorg/rizin/archive/refs/heads/dev.tar.gz"
 	tar xf "rizin.tar.gz"
 else
-	# master branch always build against latest release of rizin
+	# stable branch always build against latest release of rizin
 	wget -O "rizin.tar.xz" "https://github.com/rizinorg/rizin/releases/download/$CI_RZ_VERSION/rizin-src-$CI_RZ_VERSION.tar.xz"
 	tar xf "rizin.tar.xz"
 fi

--- a/.ci-scripts/ci-rizin-dl.py
+++ b/.ci-scripts/ci-rizin-dl.py
@@ -5,10 +5,10 @@ import os
 
 out_file = "rizin.zip"
 
-latest = "master" if len(sys.argv) < 1 else sys.argv[1]
+latest = "stable" if len(sys.argv) < 1 else sys.argv[1]
 
 if latest != "dev":
-    # master branch always build against latest release of rizin
+    # stable branch always build against latest release of rizin
     tags = None
     with urllib.request.urlopen('https://api.github.com/repos/rizinorg/rizin/tags?per_page=1') as f:
         tags = json.load(f)

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -3,7 +3,7 @@ name: build-plugin
 on:
   push:
     branches:
-      - master
+      - stable
       - dev
   pull_request:
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["stable", "dev"]
   pull_request:
-    branches: ["master"]
+    branches: ["stable", "dev"]
   schedule:
     - cron: "1 14 * * 5"
 

--- a/.github/workflows/continuous-tests.yml
+++ b/.github/workflows/continuous-tests.yml
@@ -2,7 +2,7 @@ name: continuous-tests
 on:
   push:
     branches:
-      - master
+      - stable
       - dev
   pull_request:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-![jsdec](https://raw.githubusercontent.com/rizinorg/jsdec/master/.github/logo.png)
+![jsdec](https://raw.githubusercontent.com/rizinorg/jsdec/stable/.github/logo.png)
 
 Converts asm to pseudo-C code.
 
@@ -87,5 +87,5 @@ e scr.color         | enables syntax colors.
 
 # Developing on jsdec
 
-[Read DEVELOPERS.md](https://github.com/rizinorg/jsdec/blob/master/DEVELOPERS.md)
+[Read DEVELOPERS.md](https://github.com/rizinorg/jsdec/blob/stable/DEVELOPERS.md)
 


### PR DESCRIPTION
As per discussion, since the jsdec `master` branch has been renamed to `stable`, this pr changes contents accordingly.

This pr is for the jsdec `stable` branch.