### PR TITLE
ci: Replace `windows-2019` with `windows-2022`

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         os:
           - "windows-latest"
-          - "windows-2019"
+          - "windows-2022"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
This pr replaces the CI `windows-2019` image with `windows-2022` since the `windows-2019` image [has been deprecated](https://github.com/actions/runner-images/issues/12045) for a long time and apparently is no longer available.