### PR TITLE
Enable dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Fulfilling https://github.com/rizinorg/jsdec/pull/71#issuecomment-4188298381, this pr should enable dependabot pull requests for GitHub Actions.